### PR TITLE
fix: solve cause of buttons having too-solid text color

### DIFF
--- a/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/src/components/Button/__snapshots__/Button.test.js.snap
@@ -57,7 +57,7 @@ exports[`Button Snapshots matches orientation snapshots 1`] = `
   user-select: none;
   background-color: hsl(0,0%,100%);
   border-color: transparent;
-  color: #000;
+  color: rgba(0,0,0,0.85);
   font-size: 14px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1 * 1px);
   border-radius: 4px;
@@ -164,7 +164,7 @@ exports[`Button Snapshots matches orientation snapshots 2`] = `
   user-select: none;
   background-color: hsl(0,0%,100%);
   border-color: transparent;
-  color: #000;
+  color: rgba(0,0,0,0.85);
   font-size: 14px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1 * 1px);
   border-radius: 4px;
@@ -277,7 +277,7 @@ exports[`Button Snapshots matches outline snapshots 1`] = `
   user-select: none;
   background-color: hsl(0,0%,100%);
   border-color: #e6e6e6;
-  color: #000;
+  color: rgba(0,0,0,0.85);
   font-size: 14px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1 * 1px);
   border-radius: 4px;
@@ -390,7 +390,7 @@ exports[`Button Snapshots matches size snapshots 1`] = `
   user-select: none;
   background-color: hsl(0,0%,100%);
   border-color: transparent;
-  color: #000;
+  color: rgba(0,0,0,0.85);
   font-size: 14px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1 * 1px);
   border-radius: 4px;
@@ -503,7 +503,7 @@ exports[`Button Snapshots matches size snapshots 2`] = `
   user-select: none;
   background-color: hsl(0,0%,100%);
   border-color: transparent;
-  color: #000;
+  color: rgba(0,0,0,0.85);
   font-size: 10px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1 * 1px);
   border-radius: 4px;
@@ -617,7 +617,7 @@ exports[`Button Snapshots matches size snapshots 3`] = `
   user-select: none;
   background-color: hsl(0,0%,100%);
   border-color: transparent;
-  color: #000;
+  color: rgba(0,0,0,0.85);
   font-size: 12px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1 * 1px);
   border-radius: 4px;
@@ -731,7 +731,7 @@ exports[`Button Snapshots matches size snapshots 4`] = `
   user-select: none;
   background-color: hsl(0,0%,100%);
   border-color: transparent;
-  color: #000;
+  color: rgba(0,0,0,0.85);
   font-size: 14px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1.25 * 1px);
   border-radius: 4px;
@@ -844,7 +844,7 @@ exports[`Button Snapshots matches size snapshots 5`] = `
   user-select: none;
   background-color: hsl(0,0%,100%);
   border-color: transparent;
-  color: #000;
+  color: rgba(0,0,0,0.85);
   font-size: 18px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1.25 * 1px);
   border-radius: 4px;
@@ -957,7 +957,7 @@ exports[`Button Snapshots matches type snapshots 1`] = `
   user-select: none;
   background-color: #D83D22;
   border-color: transparent;
-  color: #fff;
+  color: rgba(255,255,255,0.85);
   font-size: 14px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1 * 1px);
   border-radius: 4px;
@@ -1070,7 +1070,7 @@ exports[`Button Snapshots matches type snapshots 2`] = `
   user-select: none;
   background-color: #1E6DF6;
   border-color: transparent;
-  color: #fff;
+  color: rgba(255,255,255,0.85);
   font-size: 14px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1 * 1px);
   border-radius: 4px;
@@ -1183,7 +1183,7 @@ exports[`Button Snapshots matches type snapshots 3`] = `
   user-select: none;
   background-color: #00b42b;
   border-color: transparent;
-  color: #fff;
+  color: rgba(255,255,255,0.85);
   font-size: 14px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1 * 1px);
   border-radius: 4px;
@@ -1296,7 +1296,7 @@ exports[`Button Snapshots matches type snapshots 4`] = `
   user-select: none;
   background-color: #F7CD45;
   border-color: transparent;
-  color: #000;
+  color: rgba(0,0,0,0.85);
   font-size: 14px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1 * 1px);
   border-radius: 4px;

--- a/src/components/Button/components/ButtonWrap/__snapshots__/ButtonWrap.test.js.snap
+++ b/src/components/Button/components/ButtonWrap/__snapshots__/ButtonWrap.test.js.snap
@@ -31,7 +31,7 @@ exports[`ButtonWrap should match snapshot 1`] = `
   user-select: none;
   background-color: hsl(0,0%,100%);
   border-color: transparent;
-  color: #000;
+  color: rgba(0,0,0,0.85);
   font-size: 14px;
   padding: calc(var(--SPACING_BASE) * 0.25 * 1px)  calc(var(--SPACING_BASE) * 1 * 1px);
   border-radius: 4px;

--- a/src/components/Button/components/ButtonWrap/utils/generateButtonStyle.js
+++ b/src/components/Button/components/ButtonWrap/utils/generateButtonStyle.js
@@ -1,5 +1,5 @@
 import { css } from "styled-components";
-import { darken, readableColor, getLuminance } from "polished";
+import { darken, readableColor, getLuminance, setLightness } from "polished";
 
 // Maps button types to a particular color
 function generateButtonTypeColors(theme, type) {
@@ -30,6 +30,7 @@ function generateButtonTypeColors(theme, type) {
  * @returns string
  */
 function generateButtonStyle(theme, type, dangerouslySetColor, renderBorder) {
+
   const baseColor = dangerouslySetColor
     ? dangerouslySetColor
     : generateButtonTypeColors(theme, type);
@@ -37,7 +38,9 @@ function generateButtonStyle(theme, type, dangerouslySetColor, renderBorder) {
   const colorStyles = css`
     background-color: ${baseColor};
     border-color: ${renderBorder ? darken(0.1, baseColor) : `transparent`};
-    color: ${readableColor(darken(0.1, baseColor))};
+    color: ${readableColor(darken(0.1, baseColor),
+      setLightness(0, theme.COLOR_CONTENT_DEFAULT),
+      setLightness(1, theme.COLOR_CONTENT_DEFAULT))};
     /* darkening the color first gives a more appealing result */
   `;
 


### PR DESCRIPTION
Buttons use a white or black version of the theme's default content color, rather than a pure white or black.

This solves the issue where buttons always had a stronger text color than their surroundings. Buttons should be distinct and contrast with their surroundings, but not necessarily in this way, and not with this arbitrary restriction.