### PR TITLE
better default breadcrumb delimiter (or custom, or none)

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -60,14 +60,27 @@ const DefaultDelimiter = styled(IconChevronRight).attrs({
   margin: auto 0.25em;
 `;
 
+const EmptyDelimiter = styled.span`
+  flex: 0 0 0.5em;
+`
+
+function makeDelimiter(delimiter, i) {
+  switch (delimiter) {
+    case false:
+      return <EmptyDelimiter key={"delimiter" + i} />;
+    case undefined:
+      return <DefaultDelimiter key={"delimiter" + i} />;
+    default:
+      return cloneElement(delimiter, { key: "delimiter" + i });
+  }
+}
+
 function Breadcrumbs({ crumbs, delimiter, ...props }) {
   return (
     <BreadcrumbsWrap {...props}>
       {crumbs.map((crumb, i) => (
         <React.Fragment key={i}>
-          {delimiter !== false && 
-            i > 0 && ((delimiter !== undefined) ? cloneElement(delimiter, {key: "delimiter" + i}) : <DefaultDelimiter key={"delimiter" + i} />)
-          }
+          {i > 0 && (makeDelimiter(delimiter, i))}
           <Breadcrumb key={`${crumb}|${i}`}>
             {crumb}
           </Breadcrumb>

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -1,9 +1,9 @@
-import React from "react";
+import React, { cloneElement } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
+import { IconChevronRight } from "components/Glyphs";
 import { keen } from "style/theme";
-import { spacingScale } from "style/styleFunctions";
 
 export const BreadcrumbsWrap = styled.ol`
   font-family: ${({ theme }) => theme.FONT_STACK_DEFAULT};
@@ -36,15 +36,6 @@ export const Breadcrumb = styled.li`
     flex-shrink: 0;
   }
 
-  &:before {
-    display: inline-block;
-    visibility: ${({ hideDelimiter }) => (hideDelimiter ? "hidden" : "auto")};
-    color: ${({ theme }) => theme.COLOR_CONTENT_NONESSENTIAL};
-    padding: 0 ${spacingScale(0.5)};
-    content: ">";
-    transform: scaleX(0.5);
-  }
-
   > * {
     color: inherit;
     text-decoration: none;
@@ -53,25 +44,34 @@ export const Breadcrumb = styled.li`
       text-decoration: underline;
     }
   }
-
-  &:first-child {
-    &:before {
-      content: none;
-    }
-  }
 `;
 
 Breadcrumb.defaultProps = {
   theme: keen
 };
 
-function Breadcrumbs({ crumbs, hideDelimiter, ...props }) {
+const DefaultDelimiter = styled(IconChevronRight).attrs({
+  preserveAspectRatio: 'none'
+})`
+  pointer-events: none;
+  color: ${({ theme }) => theme.COLOR_CONTENT_NONESSENTIAL};
+  width: 0.5em;
+  height: 1em;
+  margin: auto 0.25em;
+`;
+
+function Breadcrumbs({ crumbs, delimiter, ...props }) {
   return (
     <BreadcrumbsWrap {...props}>
       {crumbs.map((crumb, i) => (
-        <Breadcrumb hideDelimiter={hideDelimiter} key={`${crumb}|${i}`}>
-          {crumb}
-        </Breadcrumb>
+        <React.Fragment key={i}>
+          {delimiter !== false && 
+            i > 0 && ((delimiter !== undefined) ? cloneElement(delimiter, {key: "delimiter" + i}) : <DefaultDelimiter key={"delimiter" + i} />)
+          }
+          <Breadcrumb key={`${crumb}|${i}`}>
+            {crumb}
+          </Breadcrumb>
+        </React.Fragment >
       ))}
     </BreadcrumbsWrap>
   );
@@ -79,12 +79,10 @@ function Breadcrumbs({ crumbs, hideDelimiter, ...props }) {
 
 Breadcrumbs.propTypes = {
   crumbs: PropTypes.array,
-  hideDelimiter: PropTypes.bool
 };
 
 Breadcrumbs.defaultProps = {
   crumbs: [],
-  hideDelimiter: false,
   theme: keen
 };
 

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -79,6 +79,7 @@ function Breadcrumbs({ crumbs, delimiter, ...props }) {
 
 Breadcrumbs.propTypes = {
   crumbs: PropTypes.array,
+  delimiter: PropTypes.oneOf([PropTypes.element, false])
 };
 
 Breadcrumbs.defaultProps = {

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { array, boolean } from "@storybook/addon-knobs";
+import { array } from "@storybook/addon-knobs";
 import { IconPlus } from "components/Glyphs";
 import { Breadcrumbs } from "..";
 

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { array, boolean } from "@storybook/addon-knobs";
+import { IconPlus } from "components/Glyphs";
 import { Breadcrumbs } from "..";
 
 const stories = storiesOf("Components|Breadcrumbs", module);
@@ -21,7 +22,6 @@ stories
       return (
         <Breadcrumbs
           crumbs={array("crumbs", defaultCrumbs)}
-          hideDelimiter={boolean("hideDelimiter")}
         />
       );
     },
@@ -45,7 +45,56 @@ stories
         >
           <Breadcrumbs
             crumbs={array("crumbs", defaultCrumbs)}
-            hideDelimiter={boolean("hideDelimiter")}
+          />
+        </div>
+      );
+    },
+    {
+      info: {
+        text: breadCrumbsInfo
+      }
+    }
+  )
+  .add(
+    "With custom delimiter",
+    () => {
+      return (
+        <div
+          style={{
+            width: "350px",
+            border: "1px solid #ddd",
+            padding: "4px",
+            borderRadius: "2px"
+          }}
+        >
+          <Breadcrumbs
+            crumbs={array("crumbs", defaultCrumbs)}
+            delimiter={<IconPlus size="1em" borderWidth={1.5} style={{ margin: 'auto', color: 'blue'}} />}
+          />
+        </div>
+      );
+    },
+    {
+      info: {
+        text: breadCrumbsInfo
+      }
+    }
+  )
+  .add(
+    "With no delimiter",
+    () => {
+      return (
+        <div
+          style={{
+            width: "350px",
+            border: "1px solid #ddd",
+            padding: "4px",
+            borderRadius: "2px"
+          }}
+        >
+          <Breadcrumbs
+            crumbs={array("crumbs", defaultCrumbs)}
+            delimiter={false}
           />
         </div>
       );

--- a/src/components/Breadcrumbs/Breadcrumbs.test.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.js
@@ -20,14 +20,14 @@ describe("Breadcrumbs", () => {
   test("renders Breadcrumb component", () => {
     expect(wrapper.find("Breadcrumb")).toHaveLength(4);
   });
-  test("passes hideDelimiter prop to Breadcrumb", () => {
-    wrapper = shallow(<Breadcrumbs crumbs={crumbs} hideDelimiter={true} />);
+  test("passes delimiter prop to Breadcrumb", () => {
+    wrapper = shallow(<Breadcrumbs crumbs={crumbs} delimiter={false} />);
     expect(
       wrapper
         .find("Breadcrumb")
         .at(0)
-        .props().hideDelimiter
-    ).toBeTruthy();
+        .props().delimiter
+    ).toBeFalsy();
   });
 });
 
@@ -38,15 +38,5 @@ describe("Breadcrumb", () => {
   });
   test("matches snapshot", () => {
     expect(wrapper).toMatchSnapshot();
-  });
-
-  test("hides delimiter when hideDelimiter prop is passed", () => {
-    let options = {
-      modifier: ":before"
-    };
-    wrapper = mount(<Breadcrumb />); // mount in order to use toHaveStyleRule
-    expect(wrapper).toHaveStyleRule("visibility", "auto", options);
-    wrapper = mount(<Breadcrumb hideDelimiter={true} />);
-    expect(wrapper).toHaveStyleRule("visibility", "hidden", options);
   });
 });

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
@@ -21,17 +21,6 @@ exports[`Breadcrumb matches snapshot 1`] = `
   flex-shrink: 0;
 }
 
-.c0:before {
-  display: inline-block;
-  visibility: auto;
-  color: hsla(0,0%,0%,0.3);
-  padding: 0  calc(var(--SPACING_BASE) * 0.5 * 1px);
-  content: ">";
-  -webkit-transform: scaleX(0.5);
-  -ms-transform: scaleX(0.5);
-  transform: scaleX(0.5);
-}
-
 .c0 > * {
   color: inherit;
   -webkit-text-decoration: none;
@@ -41,10 +30,6 @@ exports[`Breadcrumb matches snapshot 1`] = `
 .c0 > *:link:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
-}
-
-.c0:first-child:before {
-  content: none;
 }
 
 <li
@@ -123,7 +108,6 @@ exports[`Breadcrumbs matches snapshot 1`] = `
   }
 >
   <Breadcrumb
-    hideDelimiter={false}
     key="Test 1|0"
     theme={
       Object {
@@ -195,8 +179,10 @@ exports[`Breadcrumbs matches snapshot 1`] = `
   >
     Test 1
   </Breadcrumb>
+  <DefaultDelimiter
+    key="delimiter1"
+  />
   <Breadcrumb
-    hideDelimiter={false}
     key="Test 2|1"
     theme={
       Object {
@@ -268,8 +254,10 @@ exports[`Breadcrumbs matches snapshot 1`] = `
   >
     Test 2
   </Breadcrumb>
+  <DefaultDelimiter
+    key="delimiter2"
+  />
   <Breadcrumb
-    hideDelimiter={false}
     key="Test 3|2"
     theme={
       Object {
@@ -341,8 +329,10 @@ exports[`Breadcrumbs matches snapshot 1`] = `
   >
     Test 3
   </Breadcrumb>
+  <DefaultDelimiter
+    key="delimiter3"
+  />
   <Breadcrumb
-    hideDelimiter={false}
     key="Testing a really long breadcrumb item|3"
     theme={
       Object {


### PR DESCRIPTION
Main point of this update was to replace the font character-based delimiter with an icon, so we have more control over the sizing and presentation. 

**Before:**
<img width="133" alt="Screen Shot 2020-11-14 at 10 30 28 PM" src="https://user-images.githubusercontent.com/98312/99162198-017a3400-26c9-11eb-9e21-92d17bfa19b9.png">

**After:**
<img width="80" alt="Screen Shot 2020-11-14 at 10 31 29 PM" src="https://user-images.githubusercontent.com/98312/99162209-24a4e380-26c9-11eb-85ea-7f5a24979e7f.png">

Along the way, we also get a nicer way to add custom delimiters using any element passed into the `delimiter` prop, and a simple way to disable the delimiter with `delimiter={false}`.