### PR TITLE
fix: add inter as a dev dep and set peer deps to major versions only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14957,6 +14957,12 @@
         }
       }
     },
+    "inter-ui": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/inter-ui/-/inter-ui-3.15.0.tgz",
+      "integrity": "sha512-6v0WK8FHkVYbNQZ7L9O5tP8280pgTBR9ydxqYwssMuUH6SZO70ZFK/NQ1Ob8nNmOOzpUJAzT0WE73ty96z1tAQ==",
+      "dev": true
+    },
     "internal-slot": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "Grey Matter"
   ],
   "peerDependencies": {
-    "react": "^16.8",
-    "react-dom": "^16.8",
+    "react": "^16",
+    "react-dom": "^16",
     "styled-components": "^4",
-    "inter-ui": "^3.15.0"
+    "inter-ui": "^3"
   },
   "dependencies": {
     "polished": "^3.4.2"
@@ -92,6 +92,7 @@
     "eslint-plugin-react-hooks": "^1.6.1",
     "focus-visible": "^5.0.2",
     "husky": "^1.3.1",
+    "inter-ui": "^3.15.0",
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
     "jest-junit": "^6.3.0",


### PR DESCRIPTION
We were missing `inter-ui` as a dev dependency which was breaking local development. I also changed the peerDependencies to major versions as that allows consumers of the package to choose any range of minor and patch versions. I tested using `npm pack` and installed in the dashboard to confirm everything continued to work.