### PR TITLE
Project config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,6 @@
 # Set defaults for all jobs
 defaults: &defaults
   working_directory: ~/repo
-  environment:
-    CC_TEST_REPORTER_ID: c54354c67485869b121e5dcdb231ceefcbe890a99864521430f328118fb9fa4d
   docker:
     - image: circleci/node:carbon
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
   <a href="https://codeclimate.com/github/greymatter-io/gm-ui-components/maintainability"><img src="https://api.codeclimate.com/v1/badges/e4f79b8a8ac6216ae81c/maintainability" /></a>
   <a href="https://codeclimate.com/github/greymatter-io/gm-ui-components/test_coverage"><img src="https://api.codeclimate.com/v1/badges/e4f79b8a8ac6216ae81c/test_coverage" /></a>
   <a href="https://opensource.org/licenses/mit-license.php" target="_blank"><img src="https://badges.frapsoft.com/os/mit/mit.svg?v=103" alt="licensed under MIT"></a>
-  <a href="https://david-dm.org/greymatter-io/gm-ui-components" target="_blank"><img src="https://david-dm.org/greymatter-io/gm-ui-components.svg" alt="dependency vulnerabilities tracked by DavidDM"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
1. Removed CC_TEST_REPORTER_ID from source control and added it to CircleCI because we don't want to leak the ID. I also regenerated the ID, so the one that's currently in commit history will be invalid.
2. Removed david-dm as a 3rd party dependency tracker as we seldomnly use it and we receive security alerts from GitHub directly. Not to mention, that https://david-dm.org/ doesn't seem to be up anyways.