### PR TITLE
feat: squished icons remain centered

### DIFF
--- a/src/components/Icon/components/StyledSVG.js
+++ b/src/components/Icon/components/StyledSVG.js
@@ -5,7 +5,7 @@ const StyledSVG = styled.svg.attrs(() => ({
   xmlns: "http://www.w3.org/2000/svg",
   xmlnsXlink: "http://www.w3.org/1999/xlink",
   viewBox: `0 0 64 64`,
-  preserveAspectRatio: "xMaxYMax meet"
+  preserveAspectRatio: "xMidYMid meet"
 }))`
   z-index: 1;
   width: ${props => props.size};

--- a/src/components/Icon/components/__snapshots__/StyledSVG.test.js.snap
+++ b/src/components/Icon/components/__snapshots__/StyledSVG.test.js.snap
@@ -40,7 +40,7 @@ exports[`StyledSVG matches snapshot 1`] = `
 
 <svg
   className="c0"
-  preserveAspectRatio="xMaxYMax meet"
+  preserveAspectRatio="xMidYMid meet"
   size="1.714em"
   version="1.1"
   viewBox="0 0 64 64"


### PR DESCRIPTION
Sometimes icons need to be allowed to be squished relative to their viewbox. This fix ensures the icons themselves remain centered when that occurs, rather than falling to the "bottom" of the viewbox.