### PR TITLE
feat: add cross-browser input reset

### DIFF
--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -22,6 +22,7 @@ export default function InputField({
   className,
   onChange,
   onReset,
+  resettable,
   ...props
 }) {
   const [hasValue, setHasValue] = useState(false);
@@ -48,6 +49,8 @@ export default function InputField({
     }
   }
 
+  console.log(resettable);
+
   return (
     <InputWrap
       labelPosition={labelPosition}
@@ -65,9 +68,10 @@ export default function InputField({
         maxLength={maxLength}
         placeholder={placeholder}
         onChange={internalOnChange}
+        resettable={resettable}
         {...props}
       />
-      {(type === "search" || type === "text") && (
+      {resettable && (type === "search" || type === "text") && (
         <InputReset visible={hasValue} onClick={localOnReset} />
       )}
       {hint && <InputHint>{hint}</InputHint>}
@@ -88,6 +92,7 @@ InputField.propTypes = {
   onReset: PropTypes.func,
   placeholder: PropTypes.string,
   readonly: PropTypes.bool,
+  resettable: PropTypes.bool,
   style: PropTypes.object,
   type: PropTypes.oneOf([
     "email",
@@ -105,6 +110,7 @@ InputField.defaultProps = {
   disabled: false,
   labelPosition: "top",
   readonly: false,
+  resettable: false,
   type: "text"
 };
 

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -84,6 +84,8 @@ InputField.propTypes = {
   label: PropTypes.string,
   labelPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
   maxLength: PropTypes.number,
+  onChange: PropTypes.func,
+  onReset: PropTypes.func,
   placeholder: PropTypes.string,
   readonly: PropTypes.bool,
   style: PropTypes.object,

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useState, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
 
 import InputLabelText from "components/util/InputLabelText";
 import InputWrap from "components/util/InputWrap";
 import InputHint from "components/util/InputHint";
 import InputTextField from "components/util/InputTextField";
+import InputReset from "components/util/InputReset";
 
 export default function InputField({
   autoFocus,
@@ -19,8 +20,34 @@ export default function InputField({
   type,
   style,
   className,
+  onChange,
+  onReset,
   ...props
 }) {
+  const [hasValue, setHasValue] = useState(false);
+  const input = useRef(null);
+
+  useEffect(() => {
+    if (input.current.value !== "") {
+      setHasValue(true);
+    }
+  }, []); // run once on render
+
+  function internalOnChange(e) {
+    setHasValue(!!e.target.value);
+    if (onChange) {
+      onChange(e);
+    }
+  }
+
+  function localOnReset() {
+    input.current.value = "";
+    setHasValue(false);
+    if (onReset) {
+      onReset();
+    }
+  }
+
   return (
     <InputWrap
       labelPosition={labelPosition}
@@ -29,6 +56,7 @@ export default function InputField({
     >
       {label && <InputLabelText>{label}</InputLabelText>}
       <InputTextField
+        ref={input}
         type={type}
         autoFocus={autoFocus}
         defaultValue={defaultValue}
@@ -36,8 +64,12 @@ export default function InputField({
         readonly
         maxLength={maxLength}
         placeholder={placeholder}
+        onChange={internalOnChange}
         {...props}
       />
+      {(type === "search" || type === "text") && (
+        <InputReset visible={hasValue} onClick={localOnReset} />
+      )}
       {hint && <InputHint>{hint}</InputHint>}
     </InputWrap>
   );

--- a/src/components/InputField/InputField.stories.js
+++ b/src/components/InputField/InputField.stories.js
@@ -27,6 +27,8 @@ stories
         "left"
       ]);
 
+      const ResetOptions = select("resettable", [false, true]);
+
       return (
         <InputField
           autoFocus={boolean("autoFocus")}
@@ -39,6 +41,7 @@ stories
           placeholder={text("placeholder")}
           maxLength={number("maxLength")}
           labelPosition={LabelPositions}
+          resettable={ResetOptions}
         />
       );
     },

--- a/src/components/InputField/InputField.stories.js
+++ b/src/components/InputField/InputField.stories.js
@@ -58,7 +58,7 @@ stories
           label="Always use a label"
           defaultValue="User content"
           placeholder="Placeholders aren't labels"
-          labelPosition="left"
+          labelPosition="top"
         />
       );
     },

--- a/src/components/InputField/InputField.stories.js
+++ b/src/components/InputField/InputField.stories.js
@@ -20,6 +20,13 @@ stories
         "url"
       ]);
 
+      const LabelPositions = select("labelPosition", [
+        "top",
+        "right",
+        "bottom",
+        "left"
+      ]);
+
       return (
         <InputField
           autoFocus={boolean("autoFocus")}
@@ -31,6 +38,7 @@ stories
           defaultValue={text("defaultValue")}
           placeholder={text("placeholder")}
           maxLength={number("maxLength")}
+          labelPosition={LabelPositions}
         />
       );
     },
@@ -50,6 +58,7 @@ stories
           label="Always use a label"
           defaultValue="User content"
           placeholder="Placeholders aren't labels"
+          labelPosition="left"
         />
       );
     },

--- a/src/components/InputField/__snapshots__/InputField.test.js.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.js.snap
@@ -148,6 +148,7 @@ exports[`InputField matches snapshot 1`] = `
     disabled={false}
     onChange={[Function]}
     readonly={true}
+    resettable={false}
     theme={
       Object {
         "COLOR_BACKGROUND_DEFAULT": "hsl(0, 0%, 100%)",
@@ -216,77 +217,6 @@ exports[`InputField matches snapshot 1`] = `
       }
     }
     type="text"
-  />
-  <InputReset
-    onClick={[Function]}
-    theme={
-      Object {
-        "COLOR_BACKGROUND_DEFAULT": "hsl(0, 0%, 100%)",
-        "COLOR_BACKGROUND_THREE": "hsl(0, 0%, 94%)",
-        "COLOR_BACKGROUND_TWO": "#FDFDFE",
-        "COLOR_BRAND_PRIMARY": "#00b42b",
-        "COLOR_BRAND_SECONDARY": "#00b42b",
-        "COLOR_CONTENT_CONTRAST": "hsl(0, 0%, 0%)",
-        "COLOR_CONTENT_DEFAULT": "hsla(0, 0%, 0%, 0.85)",
-        "COLOR_CONTENT_MUTED": "hsla(0, 0%, 0%, 0.6)",
-        "COLOR_CONTENT_NONESSENTIAL": "hsla(0, 0%, 0%, 0.3)",
-        "COLOR_INTENT_DANGER": "#D83D22",
-        "COLOR_INTENT_HIGHLIGHT": "#00b42b",
-        "COLOR_INTENT_INFO": "#1E6DF6",
-        "COLOR_INTENT_SUCCESS": "#00b42b",
-        "COLOR_INTENT_WARNING": "#F7CD45",
-        "COLOR_KEYLINE_DEFAULT": "hsla(0, 0%, 0%, 0.08)",
-        "COLOR_KEYLINE_SOLID": "hsl(0, 0%, 92%)",
-        "CORNER_RADIUS_CARD_DEFAULT": "6px",
-        "CORNER_RADIUS_CARD_LG": "8px",
-        "CORNER_RADIUS_CARD_SM": "4px",
-        "CORNER_RADIUS_INPUT": "4px",
-        "CORNER_RADIUS_MAX": "90000px",
-        "CORNER_RADIUS_SHARP": "2px",
-        "FONT_SIZE_HEADING_DEFAULT": "36px",
-        "FONT_SIZE_HEADING_LG": "38px",
-        "FONT_SIZE_HEADING_SM": "32px",
-        "FONT_SIZE_ITEM_TITLE_DEFAULT": "14px",
-        "FONT_SIZE_ITEM_TITLE_LG": "16px",
-        "FONT_SIZE_ITEM_TITLE_SM": "12px",
-        "FONT_SIZE_PAGE_TITLE": "40px",
-        "FONT_SIZE_SUBHEADING_DEFAULT": "16px",
-        "FONT_SIZE_SUBHEADING_LG": "18px",
-        "FONT_SIZE_SUBHEADING_SM": "14px",
-        "FONT_SIZE_TEXT_DEFAULT": "14px",
-        "FONT_SIZE_TEXT_LG": "16px",
-        "FONT_SIZE_TEXT_SM": "12px",
-        "FONT_SIZE_TEXT_XL": "18px",
-        "FONT_SIZE_TEXT_XS": "10px",
-        "FONT_STACK_BRAND": "\\"Metropolis\\", \\"Helvetica Neue\\", Arial, sans-serif",
-        "FONT_STACK_CODE": "\\"SFMono-Regular\\", Consolas, \\"Liberation Mono\\", Menlo, Courier, monospace",
-        "FONT_STACK_DEFAULT": "Inter var, Inter, -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", sans-serif",
-        "FONT_WEIGHT_BOLD": 700,
-        "FONT_WEIGHT_DEFAULT": 400,
-        "FONT_WEIGHT_MEDIUM": 500,
-        "FONT_WEIGHT_SEMIBOLD": 600,
-        "LETTER_SPACING_DEFAULT": "normal",
-        "LINE_HEIGHT_DEFAULT": 1.4,
-        "LINE_HEIGHT_LOOSE": 1.6,
-        "LINE_HEIGHT_TIGHT": 1.2,
-        "OPACITY_FULL": "1",
-        "OPACITY_LIGHT": "0.7",
-        "OPACITY_LIGHTER": "0.5",
-        "OPACITY_LIGHTEST": "0.15",
-        "SPACING_BASE": 8,
-        "ZINDEX_ABYSS": "-9999",
-        "ZINDEX_DROPDOWN": "1010",
-        "ZINDEX_FIXED": "1030",
-        "ZINDEX_FLOOR": "1",
-        "ZINDEX_MODAL": "1050",
-        "ZINDEX_POPOVER": "1060",
-        "ZINDEX_SCRIM": "1040",
-        "ZINDEX_STICKY": "1020",
-        "ZINDEX_TOOLTIP": "1070",
-        "name": "Keen",
-      }
-    }
-    visible={false}
   />
 </InputWrap>
 `;

--- a/src/components/InputField/__snapshots__/InputField.test.js.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.js.snap
@@ -146,6 +146,7 @@ exports[`InputField matches snapshot 1`] = `
     autoFocus={false}
     clickAction={[Function]}
     disabled={false}
+    onChange={[Function]}
     readonly={true}
     theme={
       Object {
@@ -215,6 +216,77 @@ exports[`InputField matches snapshot 1`] = `
       }
     }
     type="text"
+  />
+  <InputReset
+    onClick={[Function]}
+    theme={
+      Object {
+        "COLOR_BACKGROUND_DEFAULT": "hsl(0, 0%, 100%)",
+        "COLOR_BACKGROUND_THREE": "hsl(0, 0%, 94%)",
+        "COLOR_BACKGROUND_TWO": "#FDFDFE",
+        "COLOR_BRAND_PRIMARY": "#00b42b",
+        "COLOR_BRAND_SECONDARY": "#00b42b",
+        "COLOR_CONTENT_CONTRAST": "hsl(0, 0%, 0%)",
+        "COLOR_CONTENT_DEFAULT": "hsla(0, 0%, 0%, 0.85)",
+        "COLOR_CONTENT_MUTED": "hsla(0, 0%, 0%, 0.6)",
+        "COLOR_CONTENT_NONESSENTIAL": "hsla(0, 0%, 0%, 0.3)",
+        "COLOR_INTENT_DANGER": "#D83D22",
+        "COLOR_INTENT_HIGHLIGHT": "#00b42b",
+        "COLOR_INTENT_INFO": "#1E6DF6",
+        "COLOR_INTENT_SUCCESS": "#00b42b",
+        "COLOR_INTENT_WARNING": "#F7CD45",
+        "COLOR_KEYLINE_DEFAULT": "hsla(0, 0%, 0%, 0.08)",
+        "COLOR_KEYLINE_SOLID": "hsl(0, 0%, 92%)",
+        "CORNER_RADIUS_CARD_DEFAULT": "6px",
+        "CORNER_RADIUS_CARD_LG": "8px",
+        "CORNER_RADIUS_CARD_SM": "4px",
+        "CORNER_RADIUS_INPUT": "4px",
+        "CORNER_RADIUS_MAX": "90000px",
+        "CORNER_RADIUS_SHARP": "2px",
+        "FONT_SIZE_HEADING_DEFAULT": "36px",
+        "FONT_SIZE_HEADING_LG": "38px",
+        "FONT_SIZE_HEADING_SM": "32px",
+        "FONT_SIZE_ITEM_TITLE_DEFAULT": "14px",
+        "FONT_SIZE_ITEM_TITLE_LG": "16px",
+        "FONT_SIZE_ITEM_TITLE_SM": "12px",
+        "FONT_SIZE_PAGE_TITLE": "40px",
+        "FONT_SIZE_SUBHEADING_DEFAULT": "16px",
+        "FONT_SIZE_SUBHEADING_LG": "18px",
+        "FONT_SIZE_SUBHEADING_SM": "14px",
+        "FONT_SIZE_TEXT_DEFAULT": "14px",
+        "FONT_SIZE_TEXT_LG": "16px",
+        "FONT_SIZE_TEXT_SM": "12px",
+        "FONT_SIZE_TEXT_XL": "18px",
+        "FONT_SIZE_TEXT_XS": "10px",
+        "FONT_STACK_BRAND": "\\"Metropolis\\", \\"Helvetica Neue\\", Arial, sans-serif",
+        "FONT_STACK_CODE": "\\"SFMono-Regular\\", Consolas, \\"Liberation Mono\\", Menlo, Courier, monospace",
+        "FONT_STACK_DEFAULT": "Inter var, Inter, -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", sans-serif",
+        "FONT_WEIGHT_BOLD": 700,
+        "FONT_WEIGHT_DEFAULT": 400,
+        "FONT_WEIGHT_MEDIUM": 500,
+        "FONT_WEIGHT_SEMIBOLD": 600,
+        "LETTER_SPACING_DEFAULT": "normal",
+        "LINE_HEIGHT_DEFAULT": 1.4,
+        "LINE_HEIGHT_LOOSE": 1.6,
+        "LINE_HEIGHT_TIGHT": 1.2,
+        "OPACITY_FULL": "1",
+        "OPACITY_LIGHT": "0.7",
+        "OPACITY_LIGHTER": "0.5",
+        "OPACITY_LIGHTEST": "0.15",
+        "SPACING_BASE": 8,
+        "ZINDEX_ABYSS": "-9999",
+        "ZINDEX_DROPDOWN": "1010",
+        "ZINDEX_FIXED": "1030",
+        "ZINDEX_FLOOR": "1",
+        "ZINDEX_MODAL": "1050",
+        "ZINDEX_POPOVER": "1060",
+        "ZINDEX_SCRIM": "1040",
+        "ZINDEX_STICKY": "1020",
+        "ZINDEX_TOOLTIP": "1070",
+        "name": "Keen",
+      }
+    }
+    visible={false}
   />
 </InputWrap>
 `;

--- a/src/components/util/InputReset.js
+++ b/src/components/util/InputReset.js
@@ -14,7 +14,9 @@ const InputReset = ({ visible = false, onClick }) => {
 };
 
 const Button = styled.button`
-  display: ${props => (props.visible === true ? "block" : "none")};
+  visibility: ${props => (props.visible === true ? "visible" : "hidden")};
+  opacity: ${props => (props.visible === true ? "1" : "0")};
+  transition: opacity 0.25s ease;
   position: absolute;
   padding: 0;
   background: inherit;

--- a/src/components/util/InputReset.js
+++ b/src/components/util/InputReset.js
@@ -1,0 +1,33 @@
+import React from "react";
+import styled from "styled-components";
+
+import { keen } from "style/theme";
+import { IconX } from "components/Glyphs";
+
+const InputReset = ({ visible = false, onClick }) => {
+  return (
+    <Button visible={visible} onClick={onClick}>
+      <IconX />
+    </Button>
+  );
+};
+
+const Button = styled.button`
+  display: ${props => (props.visible === true ? "block" : "none")};
+  position: absolute;
+  padding: 0;
+  background: inherit;
+  border: none;
+  border-radius: ${({ theme }) => theme.CORNER_RADIUS_INPUT};
+  color: ${({ theme }) => theme.COLOR_BRAND_PRIMARY};
+  font-size: ${({ theme }) => theme.FONT_SIZE_TEXT_SM};
+  font-weight: ${({ theme }) => theme.FONT_WEIGHT_BOLD};
+  z-index: 1;
+  cursor: pointer;
+`;
+
+InputReset.defaultProps = {
+  theme: keen
+};
+
+export default InputReset;

--- a/src/components/util/InputReset.js
+++ b/src/components/util/InputReset.js
@@ -22,7 +22,7 @@ const Button = styled.button`
   background: inherit;
   border: none;
   border-radius: ${({ theme }) => theme.CORNER_RADIUS_INPUT};
-  color: ${({ theme }) => theme.COLOR_BRAND_PRIMARY};
+  color: inherit;
   font-size: ${({ theme }) => theme.FONT_SIZE_TEXT_SM};
   font-weight: ${({ theme }) => theme.FONT_WEIGHT_BOLD};
   z-index: 1;

--- a/src/components/util/InputReset.js
+++ b/src/components/util/InputReset.js
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import PropTypes from "prop-types";
 
 import { keen } from "style/theme";
 import { IconX } from "components/Glyphs";
@@ -25,6 +26,11 @@ const Button = styled.button`
   z-index: 1;
   cursor: pointer;
 `;
+
+InputReset.propTypes = {
+  onClick: PropTypes.func,
+  visible: PropTypes.bool
+};
 
 InputReset.defaultProps = {
   theme: keen

--- a/src/components/util/InputTextField.js
+++ b/src/components/util/InputTextField.js
@@ -15,7 +15,7 @@ export const InputTextField = styled.input`
   border: ${BORDER_WIDTH}px solid ${({ theme }) => theme.COLOR_KEYLINE_DEFAULT};
   padding: ${spacingScale(0.5)} ${spacingScale(1)};
   padding-right: ${props =>
-    props.type === "search" || props.type === "text"
+    props.resettable && (props.type === "search" || props.type === "text")
       ? spacingScale(3)
       : spacingScale(1)};
   appearance: none;

--- a/src/components/util/InputTextField.js
+++ b/src/components/util/InputTextField.js
@@ -14,6 +14,10 @@ export const InputTextField = styled.input`
   );
   border: ${BORDER_WIDTH}px solid ${({ theme }) => theme.COLOR_KEYLINE_DEFAULT};
   padding: ${spacingScale(0.5)} ${spacingScale(1)};
+  padding-right: ${props =>
+    props.type === "search" || props.type === "text"
+      ? spacingScale(3)
+      : spacingScale(1)};
   appearance: none;
   margin: 0;
   color: ${({ theme }) => theme.COLOR_CONTENT_DEFAULT};
@@ -28,6 +32,12 @@ export const InputTextField = styled.input`
 
   &::-webkit-search-decoration {
     -webkit-appearance: none;
+  }
+
+  // not supported in Firefox
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-search-cancel-button
+  &::-webkit-search-cancel-button {
+    display: none;
   }
 
   &:hover {

--- a/src/components/util/InputWrap.js
+++ b/src/components/util/InputWrap.js
@@ -3,11 +3,37 @@ import { keen } from "style/theme";
 import { spacingScale } from "style/styleFunctions";
 
 const InputWrap = styled.label`
-  ${props => getPosition(props.labelPosition)};
   color: ${({ theme }) => theme.COLOR_CONTENT_DEFAULT};
   font-family: ${({ theme }) => theme.FONT_STACK_DEFAULT};
-  display: flex;
+  display: grid;
   position: relative;
+  grid-template-columns: 4fr auto auto auto;
+  grid-template-rows: auto auto auto;
+  grid-template-areas:
+    "label label label label"
+    "input button . ."
+    "small small small small";
+
+  p {
+    grid-area: label;
+  }
+
+  input,
+  textarea,
+  select {
+    grid-area: input;
+  }
+
+  button {
+    grid-area: button;
+    justify-self: start;
+    align-self: center;
+  }
+
+  small {
+    grid-area: small;
+  }
+  ${props => getPosition(props.labelPosition)};
 
   &:active {
     /* Prevent text selection when user clicks label to focus input.
@@ -24,28 +50,41 @@ function getPosition(position) {
   switch (position) {
     case "left":
       return css`
-        flex-direction: row;
-        align-items: center;
+        grid-template-areas: "label input button small";
+        > button {
+          grid-column: 2 / 3;
+          right: 5px;
+        }
         > input,
         > textarea,
         > select {
-          margin-left: ${spacingScale(0.5)};
+          margin: 0 ${spacingScale(0.5)};
         }
       `;
     case "right":
       return css`
-        flex-direction: row-reverse;
-        justify-content: flex-end;
-        align-items: center;
+        grid-template-areas: "small input button label";
+        > button {
+          grid-column: 3 / 4;
+          right: 8px;
+        }
         > input,
         > textarea,
         > select {
-          margin-right: ${spacingScale(0.5)};
+          margin: 0 ${spacingScale(0.5)};
         }
       `;
     case "bottom":
       return css`
-        flex-direction: column-reverse;
+        grid-template-areas:
+          "small small small small"
+          "input . . button"
+          "label label label label";
+        > button {
+          grid-column: 1 / 2;
+          right: 3px;
+          bottom: 9px;
+        }
         > input,
         > textarea,
         > select {
@@ -55,7 +94,11 @@ function getPosition(position) {
     default:
     case "top":
       return css`
-        flex-direction: column;
+        > button {
+          grid-column: 1 / 2;
+          right: 3px;
+          bottom: 5px;
+        }
         > input,
         > textarea,
         > select {

--- a/src/components/util/__snapshots__/InputTextField.test.js.snap
+++ b/src/components/util/__snapshots__/InputTextField.test.js.snap
@@ -6,6 +6,7 @@ exports[`InputTextField matches snapshot 1`] = `
   border-radius: calc( 4px + 1px );
   border: 1px solid hsla(0,0%,0%,0.08);
   padding: calc(var(--SPACING_BASE) * 0.5 * 1px)  calc(var(--SPACING_BASE) * 1 * 1px);
+  padding-right: calc(var(--SPACING_BASE) * 1 * 1px);
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -77,6 +78,10 @@ exports[`InputTextField matches snapshot 1`] = `
 
 .c0::-webkit-search-decoration {
   -webkit-appearance: none;
+}
+
+.c0::-webkit-search-cancel-button {
+  display: none;
 }
 
 .c0::-webkit-input-placeholder {


### PR DESCRIPTION
This PR adds cross-browser input reset functionality for `text` and `search` inputs.

How to test:

1. `npm start` and smoke test InputField via storybook
2. Test with an app following https://github.com/greymatter-io/gm-ui-components/blob/main/CONTRIBUTING.md#npm-pack