### PR TITLE
chore: Cut release of gm ui components 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2.1.2](https://github.com/greymatter-io/gm-ui-components/compare/v2.1.1...v2.1.2) (2022-07-05)
+
+
+### Bug Fixes
+
+* Changed alt text and copyright to from Decipher to greymatter.io Inc. ([#636](https://github.com/greymatter-io/gm-ui-components/issues/636)) ([ac02521](https://github.com/greymatter-io/gm-ui-components/commit/ac0252118084e08ba0f3d86c688a873a0565b931))
+
+
+
 ## [2.1.1](https://github.com/greymatter-io/gm-ui-components/compare/v2.1.0...v2.1.1) (2021-09-03)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Features
 
-* Changed alt text and copyright to from Decipher to greymatter.io Inc. ([#636](https://github.com/greymatter-io/gm-ui-components/issues/636)) ([ac02521](https://github.com/greymatter-io/gm-ui-components/commit/ac0252118084e08ba0f3d86c688a873a0565b931))
+* Changed alt text and copyright from Decipher to greymatter.io Inc. ([#636](https://github.com/greymatter-io/gm-ui-components/issues/636)) ([ac02521](https://github.com/greymatter-io/gm-ui-components/commit/ac0252118084e08ba0f3d86c688a873a0565b931))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2.1.2](https://github.com/greymatter-io/gm-ui-components/compare/v2.1.1...v2.1.2) (2022-07-05)
 
 
-### Bug Fixes
+### Features
 
 * Changed alt text and copyright to from Decipher to greymatter.io Inc. ([#636](https://github.com/greymatter-io/gm-ui-components/issues/636)) ([ac02521](https://github.com/greymatter-io/gm-ui-components/commit/ac0252118084e08ba0f3d86c688a873a0565b931))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-ui-components",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gm-ui-components",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A library of reusable UI components for the Grey Matter product suite.",
   "main": "lib/build.js",
   "author": "Decipher Technology Studios",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.2",
   "description": "A library of reusable UI components for the Grey Matter product suite.",
   "main": "lib/build.js",
-  "author": "Decipher Technology Studios",
+  "author": "greymatter.io",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
[sc-18596] Cut release of gm ui components 

Created a new release with changes to the footers logo image and copyright.

When I try to link this with my gm-dashboard 6.0.2 branch, I get this error in the dashboard:
`Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.`

and when I try to link it with the current 'main' branch of gm-dashboard, I don't see any changes in the footer, specifically the logo image, seeing as the copyright was updated in the files of the 'main' branch.